### PR TITLE
Move the menuitem to the bottom of the context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-duplicate",
   "displayName": "Duplicate file",
   "description": "Ability to duplicate files in VS Code",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "publisher": "mrmlnc",
   "license": "MIT",
   "engines": {
@@ -34,8 +34,7 @@
     }],
     "menus": {
       "explorer/context": [{
-        "command": "duplicate.execute",
-        "group": "navigation"
+        "command": "duplicate.execute"
       }]
     }
   },


### PR DESCRIPTION
Remove the "group: navigation" entry. The duplicate command is not related to navigation and it fits better next to the Rename & Delete commands.
