### PR TITLE
[Fix] Change the suffix position (#46, #47, #49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 We use [GitHub's Releases feature](https://github.com/blog/1547-release-your-software) for changelogs.
 
-See [the Releases section of our GitHub project](https://github.com/mrmlnc/vscode-duplicate/releases) for changelogs for each release version of this plugin.
+See [the Releases section of our GitHub project](https://github.com/trandaison/vscode-duplicate/releases) for changelogs for each release version of this plugin.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 
 There are a couple of ways you can contribute to this repo:
 
-  * **Ideas, feature requests and bugs**: We are open to all ideas and we want to get rid of bugs! Use the [Issues section](https://github.com/mrmlnc/vscode-duplicate/issues) to either report a new issue, provide your ideas or contribute to existing threads.
+  * **Ideas, feature requests and bugs**: We are open to all ideas and we want to get rid of bugs! Use the [Issues section](https://github.com/trandaison/vscode-duplicate/issues) to either report a new issue, provide your ideas or contribute to existing threads.
   * **Documentation**: Found a typo or strangely worded sentences? Submit a PR!
   * **Code**: Contribute bug fixes, features or design changes.
 
@@ -16,7 +16,7 @@ There are a couple of ways you can contribute to this repo:
 
 Before you create a new Issue:
 
-  * Check the [Issues](https://github.com/mrmlnc/vscode-duplicate/issues) on Github to ensure one doesn't already exist.
+  * Check the [Issues](https://github.com/trandaison/vscode-duplicate/issues) on Github to ensure one doesn't already exist.
   * Clearly describe the issue, including the steps to reproduce the issue.
 
 ### Making Changes

--- a/README.md
+++ b/README.md
@@ -1,14 +1,8 @@
+> This extension was forked from [mrmlnc/vscode-duplicate](https://github.com/mrmlnc/vscode-duplicate), it's a alternative version since the [mrmlnc/vscode-duplicate](https://github.com/mrmlnc/vscode-duplicate) is no longer being maintained for years.
+
 # vscode-duplicate
 
 > Ability to duplicate files and directories in VS Code.
-
-## Donate
-
-If you want to thank me, or promote your Issue.
-
-[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://paypal.me/mrmlnc)
-
-> Sorry, but I have work and support for plugins and modules requires some time after work. I will be glad of your support or PR's.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "vscode-duplicate",
+  "name": "@trandaison/vscode-duplicate",
   "displayName": "Duplicate action",
   "description": "Ability to duplicate files in VS Code",
-  "version": "1.2.1",
-  "publisher": "mrmlnc",
+  "version": "2.0.0",
+  "publisher": "trandaison",
   "license": "MIT",
   "engines": {
     "vscode": "^1.13.0"
   },
   "icon": "icon.png",
-  "homepage": "https://github.com/mrmlnc/vscode-duplicate/blob/master/README.md",
+  "homepage": "https://github.com/trandaison/vscode-duplicate/blob/master/README.md",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mrmlnc/vscode-duplicate"
+    "url": "https://github.com/trandaison/vscode-duplicate"
   },
   "keywords": [
     "duplicate",
@@ -22,9 +22,6 @@
   ],
   "categories": [
     "Other"
-  ],
-  "activationEvents": [
-    "onCommand:duplicate.execute"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -1,14 +1,15 @@
 import * as vscode from 'vscode';
 
 export function name(filename: string): Promise<string | undefined> {
+	const value = filename.replace(/(\.[^.]+)$/, '-copy.$1');
 	return vscode.window.showInputBox({
+		value,
 		placeHolder: 'Enter the new path for the duplicate.',
-		value: filename.split('.').map((el, i) => i === 0 ? `${el}-copy` : el).join('.')
 	}) as Promise<string | undefined>;
 }
 
 export function overwrite(filepath: string): Promise<vscode.MessageItem | undefined> {
-	const message = `The path **${filepath}** alredy exists. Do you want to overwrite the existing path?`;
+	const message = `The path **${filepath}** already exists. Do you want to overwrite the existing path?`;
 	const action = {
 		title: 'OK',
 		isCloseAffordance: false


### PR DESCRIPTION
### What is the purpose of this pull request?
- #46 Move the suffix `-copy` to the end of the file name (right before `.extension`).
- Fix issue #47 & #49

### What changes did you make? (Give an overview)
- N/a