### PR TITLE
extended docs to show conditional shortcut execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ To change keyboard shortcuts, create a new rule in `File -> Preferences -> Keybo
 }
 ```
 
+In case of shortcut overlaps you might want to specify a when clause, for example "only when the file explorer is in focus":
+
+```json
+{
+  "key": "ctrl+shift+d",
+  "command": "duplicate.execute",
+  "when": "explorerViewletFocus"
+}
+```
+
 ## Changelog
 
 See the [Releases section of our GitHub project](https://github.com/mrmlnc/vscode-duplicate/releases) for changelogs for each release version.


### PR DESCRIPTION
I had other extensions using the same shortcut I wanted to use for duplication, so I had to find out how to make it conditional so that it would only run, when I focus the file in the explorer.

Thought this might be helpful information for other users as well.

### What is the purpose of this pull request?

Improve readme.

### What changes did you make? (Give an overview)

Added some json to readme.